### PR TITLE
Fix/git credentials script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -191,8 +191,8 @@ function clone_repos {
 error_counter=0
 commands=(
     "install_apt_deps"
-    "clone_repos"
     "install_pip_deps"
+    "clone_repos"
     "install_module_resources \"$PATH_PIP_SEARCH_FOLDER\""
     "install_ros_deps"
 )

--- a/setup_git_credentials.sh
+++ b/setup_git_credentials.sh
@@ -63,6 +63,16 @@ function handle_options {
 # Main script execution
 handle_options "$@"
 
+function check_git_installed {
+    if which git &> /dev/null; then
+        echo "Git is installed"
+    else
+        echo "Installing git"
+        apt update && apt install -y git
+    fi
+    return 0
+}
+
 function set_git_credentials {
     # echo "https://gitlab-ci-token:$CI_JOB_TOKEN@gitlab.com" > ~/.git-credentials
     # git config --global credential.helper store
@@ -78,7 +88,7 @@ function set_git_credentials {
 #     cat ~/.gitconfig
 
     rv=0
-
+    
     if [ -n "$GIT_CREDENTIALS_FILE" ]; then
         cp $GIT_CREDENTIALS_FILE ~/.git-credentials
         if [ $? -ne 0 ]; then
@@ -106,6 +116,7 @@ function set_git_credentials {
 
 error_counter=0
 commands=(
+    "check_git_installed"
     "set_git_credentials"
 )
 


### PR DESCRIPTION
Added two fixes:

1. Reordered function calls in install scripts to install vcs before cloning repos
2. Fixed commands list in git credentials scripts and added function to check availability of git. This is needed because credentials are configured before install.sh script is called which installs git. This lead to problems with credential storage.